### PR TITLE
Fixed Issue #8 and #9

### DIFF
--- a/CLEO4/CCustomOpcodeSystem.cpp
+++ b/CLEO4/CCustomOpcodeSystem.cpp
@@ -394,6 +394,8 @@ namespace CLEO
 			{
 				size = size > 128 || !size ? 128 : size;
 				strncpy(buf, opcodeParams[0].pcParam, size - 1);
+
+				buf[size - 1] = 0;
 			}
 
 			return opcodeParams[0].pcParam;

--- a/CLEO4/CCustomOpcodeSystem.cpp
+++ b/CLEO4/CCustomOpcodeSystem.cpp
@@ -1733,7 +1733,7 @@ loop_end_0AA8:
 		if (deleted_thread)
 		{
 			GetInstance().ScriptEngine.RemoveCustomScript(deleted_thread);
-			delete deleted_thread;
+			//delete deleted_thread; // Causes Heap Corruption
 		}
 		return deleted_thread == thread ? OR_INTERRUPT : OR_CONTINUE;
 	}	

--- a/CLEO4/CCustomOpcodeSystem.cpp
+++ b/CLEO4/CCustomOpcodeSystem.cpp
@@ -389,6 +389,13 @@ namespace CLEO
 		{
 			// process parameter as a pointer to string
 			GetScriptParams(thread, 1);
+
+			if (buf != nullptr)
+			{
+				size = size > 128 || !size ? 128 : size;
+				strncpy(buf, opcodeParams[0].pcParam, size - 1);
+			}
+
 			return opcodeParams[0].pcParam;
 		}
 		else
@@ -1733,7 +1740,6 @@ loop_end_0AA8:
 		if (deleted_thread)
 		{
 			GetInstance().ScriptEngine.RemoveCustomScript(deleted_thread);
-			//delete deleted_thread; // Causes Heap Corruption
 		}
 		return deleted_thread == thread ? OR_INTERRUPT : OR_CONTINUE;
 	}	

--- a/CLEO4/CScriptEngine.cpp
+++ b/CLEO4/CScriptEngine.cpp
@@ -718,12 +718,21 @@ namespace CLEO
 					TRACE("Finished. Loaded %u cleo variables, %u saved threads info, %u stopped threads info", 
 						0x400, safe_header.n_saved_threads, safe_header.n_stopped_threads);
 				}
+				else
+				{
+					memset(CleoVariables, 0, sizeof(CleoVariables));
+				}
 			}
 			catch (std::exception& ex)
 			{
 				TRACE("Loading of cleo safe %s failed: %s", safe_name, ex.what());
 				safe_header.n_saved_threads = safe_header.n_stopped_threads = 0;
+				memset(CleoVariables, 0, sizeof(CleoVariables));
 			}
+		}
+		else
+		{
+			memset(CleoVariables, 0, sizeof(CleoVariables));
 		}
 
 		char cwd[MAX_PATH];


### PR DESCRIPTION
Shared Variables aren't reset properly
0ABA causes heap corruption
Bug on some text opcodes when send pointer to it.