### PR TITLE
fix position & remove flag

### DIFF
--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -689,7 +689,7 @@ namespace CLEO
 
         // steam offset is different, so get it manually for now
         CGameVersionManager& gvm = GetInstance().VersionManager;
-        int nSlot = gvm.GetGameVersion() != GV_STEAM ? *(BYTE*)&MenuManager->m_bSelectedSaveGame : *((BYTE*)MenuManager + 0x15B);
+        int nSlot = gvm.GetGameVersion() != GV_STEAM ? *(BYTE*)&MenuManager->m_nSelectedSaveGame : *((BYTE*)MenuManager + 0x15B);
 
         sprintf(safe_name, "./cleo/cleo_saves/cs%d.sav", nSlot);
 
@@ -818,7 +818,7 @@ namespace CLEO
 
             // steam offset is different, so get it manually for now
             CGameVersionManager& gvm = GetInstance().VersionManager;
-            int nSlot = gvm.GetGameVersion() != GV_STEAM ? *(BYTE*)&MenuManager->m_bSelectedSaveGame : *((BYTE*)MenuManager + 0x15B);
+            int nSlot = gvm.GetGameVersion() != GV_STEAM ? *(BYTE*)&MenuManager->m_nSelectedSaveGame : *((BYTE*)MenuManager + 0x15B);
 
             char safe_name[MAX_PATH];
             sprintf(safe_name, "./cleo/cleo_saves/cs%d.sav", nSlot);

--- a/source/CSoundSystem.cpp
+++ b/source/CSoundSystem.cpp
@@ -98,7 +98,7 @@ namespace CLEO
             total_devices, enabled_devices, default_device, BASS_GetDeviceInfo(default_device, &info) ?
             info.name : "Unknown device");
 
-        if (BASS_Init(default_device, 44100, BASS_DEVICE_3D | BASS_DEVICE_DEFAULT, hwnd, nullptr) &&
+        if (BASS_Init(default_device, 44100, BASS_DEVICE_3D, hwnd, nullptr) &&
             BASS_Set3DFactors(1.0f, 0.3f, 1.0f) &&
             BASS_Set3DPosition(&pos, &vel, &front, &top))
         {
@@ -402,7 +402,7 @@ namespace CLEO
             }
             else
             {
-                BASS_ChannelSet3DPosition(streamInternal, &BASS_3DVECTOR(position.y, position.z, position.x), nullptr, nullptr);
+                BASS_ChannelSet3DPosition(streamInternal, &position, nullptr, nullptr);
                 //BASS_ChannelGet3DPosition(streamInternal, &position, nullptr, nullptr);
             }
         }


### PR DESCRIPTION
I was interested in the issue of #59. I also found another problem. When calling `0AC2: set_play_3d_audio_stream_at_coords` the position of the audio changes with the coordinate axes rearranged.
https://github.com/cleolibrary/CLEO4/blob/f179256d4f6af671f77e35e9af23d1bb33381005/source/CSoundSystem.cpp#L367-L369
And then again in the method `C3DAudioStream::Process()` the coordinates are transposed.
https://github.com/cleolibrary/CLEO4/blob/f179256d4f6af671f77e35e9af23d1bb33381005/source/CSoundSystem.cpp#L405
Because of that the sound was not audible.

I also changed a couple of fields for the newer plugin sdk, maybe how to separate this change.

Issues Found:
- When loading ogg in stereo, for 3d audio, stream creation gets an error with code 20 - `BASS_ERROR_ILLPARAM`. As I understand it is just because 3d requires mono audio. Flag `BASS_SAMPLE_MONO` for some reason has no effect. Maybe I did something wrong.
- I don't know how much of a problem this is, but my mp3 still works as mono, but ogg just works right.