### PR TITLE
Unlock audio file

### DIFF
--- a/source/CSoundSystem.h
+++ b/source/CSoundSystem.h
@@ -1,5 +1,8 @@
 #pragma once
 #include "stdafx.h"
+
+#include <map>
+
 #include "CCodeInjector.h"
 #include <set>
 #include "bass.h"
@@ -21,6 +24,7 @@ namespace CLEO
         bool paused;
         bool bUseFPAudio;
         HWND hwnd;
+        std::map<std::string, std::pair<unsigned int, std::vector<byte>>> cachedAudioFiles;
 
     public:
         virtual void Inject(CCodeInjector& inj);
@@ -70,10 +74,14 @@ namespace CLEO
             stopped,
         } state;
         bool OK;
+        std::string audioFile;
+
         CAudioStream();
+        static unsigned calculateAudioStreamFlags();
 
     public:
         CAudioStream(const char *src);
+        CAudioStream(const std::vector<BYTE>* fileBytes, const char* filename);
         virtual ~CAudioStream();
 
         // actions on streams
@@ -103,8 +111,12 @@ namespace CLEO
     protected:
         CPlaceable	*	link;
         BASS_3DVECTOR	position;
+
+        static unsigned calculate3dAudioStreamFlags();
+        void set3dAttributes();
     public:
         C3DAudioStream(const char *src);
+        C3DAudioStream(const std::vector<BYTE>* fileBytes, const char* filename);
         virtual ~C3DAudioStream();
 
         // overloaded actions

--- a/source/stdafx.h
+++ b/source/stdafx.h
@@ -126,6 +126,26 @@ inline bool	IsWrecked(CVehicle* pSelf)
     return pSelf->m_nStatus == STATUS_WRECKED || pSelf->m_nVehicleFlags.bIsDrowning;
 }
 
+inline std::vector<BYTE> ReadFileToBytes(const char* filename)
+{
+    std::ifstream file(filename, std::ios::binary);
+    file.unsetf(std::ios::skipws);
+
+    file.seekg(0, std::ios::end);
+    const std::streampos fileSize = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    // reserve capacity
+    std::vector<BYTE> vec;
+    vec.reserve(fileSize);
+
+    // read the data:
+    vec.insert(vec.begin(),
+        std::istream_iterator<BYTE>(file),
+        std::istream_iterator<BYTE>());
+
+    return vec;
+}
 
 #define OP_NOP			0x90
 #define OP_RET			0xC3


### PR DESCRIPTION
In continuation of #61  I encountered that reading audio from the file, so that for the lifetime of the audio stream, the file is blocked. My changes change the way the audio is read. When the audiosteam is created, the file is read and written to memory, and then the file is unlocked and the audio is read from memory. Maybe I should have put this in a separate logic, because this way has pros and cons (below).

## Pros:
- The audio file is blocked only for a single read into memory
- Audio is cached, if you load the same file in two audio streams, the reading time will be spent once
## Cons:
- It takes time to load the file into memory, which may cause existing scripts to freeze where they should not. (The solution is to load the audio stream in advance, not in the place where you need to play)
- Very large files will take a very long time to load.