### PR TITLE
fix scm function (0AB1, 0AB2) conditional result scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.3
+
+- added correct support of condition result to opcodes 0AB1 0AB2. Fixes possible bugs when 0AB1 are used in multi conditional if statements. 
+
 ## 4.4.2
 
 - fix eventual crash when using the game's user track player radio station (see https://github.com/cleolibrary/CLEO4/issues/38 for details)

--- a/source/CCustomOpcodeSystem.cpp
+++ b/source/CCustomOpcodeSystem.cpp
@@ -810,6 +810,8 @@ namespace CLEO {
 		unsigned short prevScmFunctionId, thisScmFunctionId;
 		BYTE *retnAddress;
 		SCRIPT_VAR savedTls[32];
+		bool savedCondResult;
+		eLogicalOperation savedLogicalOp;
 		static const size_t store_size = 0x400;
 		static ScmFunction *Store[store_size];
 		static size_t allocationPlace;			// contains an index of last allocated object
@@ -838,22 +840,48 @@ namespace CLEO {
 		{
 			auto cs = reinterpret_cast<CCustomScript*>(thread);
 
+			// create snapshot of current scope
 			auto scope = cs->IsMission() ? missionLocals : cs->LocalVar;
 			std::copy(scope, scope + 32, savedTls);
+			savedCondResult = cs->bCondResult;
+			savedLogicalOp = cs->LogicalOp;
 
+			// initialize new scope
 			SCRIPT_VAR fill_val; fill_val.dwParam = 0;
 
 			// CLEO 3 didnt initialise local storage, so dont do it if we're processing a CLEO 3 script in case the storage is used
 			if (cs->IsCustom() && cs->GetCompatibility() >= CLEO_VER_4_MIN)
 				std::fill(scope, scope + 32, fill_val);	// fill with zeros
 
+			cs->bCondResult = false;
+			cs->LogicalOp = eLogicalOperation::NONE;
+
 			cs->SetScmFunction(thisScmFunctionId = allocationPlace);
 		}
 
 		void Return(CRunningScript *thread)
 		{
+			// restore parent scope's local variables
 			auto cs = reinterpret_cast<CCustomScript*>(thread);
 			std::copy(savedTls, savedTls + 32, cs->IsMission() ? missionLocals : cs->LocalVar);
+
+			// process conditional result of just ended function in parent scope
+			if (savedLogicalOp >= eLogicalOperation::AND_2 && savedLogicalOp < eLogicalOperation::AND_END)
+			{
+				cs->bCondResult = savedCondResult && cs->bCondResult;
+				cs->LogicalOp = --savedLogicalOp;
+			}
+			else if(savedLogicalOp >= eLogicalOperation::OR_2 && savedLogicalOp < eLogicalOperation::OR_END)
+			{
+				cs->bCondResult = savedCondResult || cs->bCondResult;
+				cs->LogicalOp = --savedLogicalOp;
+			}
+			else // eLogicalOperation::NONE
+			{
+				// bCondResult already contains ened scope's result
+				cs->LogicalOp = savedLogicalOp;
+			}
+
 			cs->SetIp(retnAddress);
 			cs->SetScmFunction(prevScmFunctionId);
 		}

--- a/source/CScriptEngine.cpp
+++ b/source/CScriptEngine.cpp
@@ -319,7 +319,7 @@ namespace CLEO
         unsigned timers[2];
         bool condResult;
         unsigned sleepTime;
-        unsigned short logicalOp;
+        eLogicalOperation logicalOp;
         bool notFlag;
         ptrdiff_t ip_diff;
         char threadName[8];

--- a/source/CTheScripts.h
+++ b/source/CTheScripts.h
@@ -24,6 +24,36 @@ enum eDataType
     DT_LVAR_STRING_ARRAY
 };
 
+enum eLogicalOperation : WORD
+{
+    NONE = 0, // just replace
+
+    AND_2 = 1, // AND operation on results of next two conditional opcodes
+    AND_3,
+    AND_4,
+    AND_5,
+    AND_6,
+    AND_7,
+    AND_END,
+
+    OR_2 = 21, // OR operation on results of next two conditional opcodes
+    OR_3,
+    OR_4,
+    OR_5,
+    OR_6,
+    OR_7,
+    OR_END,
+};
+static eLogicalOperation& operator--(eLogicalOperation& o)
+{
+    if (o == eLogicalOperation::NONE) return o; // can not be decremented anymore
+    if (o == eLogicalOperation::OR_2) return o = eLogicalOperation::NONE;
+
+    auto val = static_cast<WORD>(o); // to number
+    val--;
+    return o = static_cast<eLogicalOperation>(val);
+}
+
 union SCRIPT_VAR
 {
     DWORD	dwParam;
@@ -57,7 +87,7 @@ protected:
     bool bTextBlockOverride;			// +0xC8
     BYTE bExternalType;					// +0xC9
     DWORD WakeTime;						// +0xCC
-    WORD LogicalOp;						// +0xD0
+    eLogicalOperation LogicalOp;		// +0xD0
     bool NotFlag;						// +0xD2
     bool bWastedBustedCheck;			// +0xD3
     bool bWastedOrBusted;				// +0xD4
@@ -250,7 +280,7 @@ public:
         bTextBlockOverride = 0;
         bExternalType = -1;
         memset(LocalVar, 0, sizeof(LocalVar));
-        LogicalOp = 0;
+        LogicalOp = eLogicalOperation::NONE;
         NotFlag = 0;
         bWastedOrBusted = 0;
         SceneSkipIP = 0;


### PR DESCRIPTION
Added correct support of condition result to opcodes 0AB1 0AB2. Fixes possible bugs when 0AB1 are used in multi conditional if statements