### PR TITLE
Main menu cleo text aspect fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - 'argument count' parameter of 0AB2 (cleo_return) is now optional. 'cleo_return 0' can be written as 'cleo_return'
 - fixed handling of strings longer than 128 characters causing errors in some cases
 - fixed error in handling of first string argument in 0AF5 (write_string to_ini_file)
+- fixed resolution dependent aspect ratio of CLEO text in main menu
 #### SDK AND PLUGINS
 - now all opcodes in range 0-7FFF can be registered by plugins
 - plugins moved to cleo\cleo_plugins directory

--- a/CLEO4.vcxproj
+++ b/CLEO4.vcxproj
@@ -11,6 +11,15 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CFont.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\RenderWare.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\shared\game\CRGBA.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="source\CCodeInjector.cpp" />
     <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CFileMgr.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>

--- a/CLEO4.vcxproj.filters
+++ b/CLEO4.vcxproj.filters
@@ -48,6 +48,15 @@
     <ClCompile Include="$(PLUGIN_SDK_DIR)\shared\PluginBase.cpp">
       <Filter>plugin_sdk</Filter>
     </ClCompile>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\shared\game\CRGBA.cpp">
+      <Filter>plugin_sdk</Filter>
+    </ClCompile>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\CFont.cpp">
+      <Filter>plugin_sdk</Filter>
+    </ClCompile>
+    <ClCompile Include="$(PLUGIN_SDK_DIR)\plugin_sa\game_sa\RenderWare.cpp">
+      <Filter>plugin_sdk</Filter>
+	</ClCompile>
     <ClCompile Include="source\crc32.cpp">
       <Filter>source\utils</Filter>
     </ClCompile>

--- a/source/CGameMenu.cpp
+++ b/source/CGameMenu.cpp
@@ -2,52 +2,15 @@
 #include "CGameMenu.h"
 #include "CleoBase.h"
 #include "CDebug.h"
+#include "CFont.h"
 #include <sstream>
 
 namespace CLEO
 {
-    void(__cdecl	* TextDraw)				(float x, float y, const char* text);
-    void(__cdecl	* SetTextAlign)			(BYTE nAlign);
-    void(__cdecl	* SetTextFont)			(BYTE nFont);
-    void(__cdecl* SetTextEdge)			(char nEdge);
-    void(__cdecl	* SetLetterSize)			(float w, float h);
-    void(__cdecl	* SetLetterColor)		(RGBA color);
+    CMenuManager* MenuManager;
 
-    // thiscalls dont work with memory_pointer operator overload template
-    DWORD	CMenuManager__ScaleX;
-    DWORD	CMenuManager__ScaleY;
-    DWORD	CTexture__DrawInRect;
-    //void	(__thiscall	* CTexture__DrawInRect)	(void *texture, RwRect2D *rect, RwRGBA color);
-
-    CMenuManager *	MenuManager;
-
-    float CGameMenu_ScaleX(CMenuManager *pMenu, float w)
-    {
-        float fReturn;
-        _asm
-        {
-            mov ecx, pMenu
-            push w
-            call CMenuManager__ScaleX
-            fstp fReturn
-        }
-        return fReturn;
-    }
-
-    float CGameMenu_ScaleY(CMenuManager *pMenu, float w)
-    {
-        float fReturn;
-        _asm
-        {
-            mov ecx, pMenu
-            push w
-            call CMenuManager__ScaleY
-            fstp fReturn
-        }
-        return fReturn;
-    }
-
-    void CTexture_DrawInRect(void *pTexture, RwRect2D *rect, RwRGBA *colour)
+    DWORD CTexture__DrawInRect; // original address
+    void CTexture_DrawInRect(void* pTexture, RwRect2D* rect, RwRGBA* colour)
     {
         _asm
         {
@@ -60,36 +23,56 @@ namespace CLEO
 
     void __fastcall OnDrawMenuBackground(void *texture, int dummy, RwRect2D *rect, RwRGBA *color)
     {
-        CTexture_DrawInRect(texture, rect, color);
+        CTexture_DrawInRect(texture, rect, color); // call original
+
+        CFont::SetBackground(false, false);
+        CFont::SetWrapx(640.0f);
+        CFont::SetFontStyle(FONT_MENU);
+        CFont::SetProportional(true);
+        CFont::SetOrientation(ALIGN_LEFT);
+
+        CFont::SetColor({ 0xAD, 0xCE, 0xC4, 0xFF });
+        CFont::SetEdge(1);
+        CFont::SetDropColor({ 0x00, 0x00, 0x00, 0xFF });
+
+        const float fontSize = 0.5f / 448.0f;
+        const float aspect = (float)RsGlobal.maximumWidth / RsGlobal.maximumHeight;
+        const float subtextHeight = 0.75f; // factor of first line height
+        float sizeX = fontSize * 0.5f / aspect * RsGlobal.maximumWidth;
+        float sizeY = fontSize * RsGlobal.maximumHeight;
+
+        float posX = 25.0f * sizeX; // left margin
+        float posY = RsGlobal.maximumHeight - 15.0f * sizeY; // bottom margin
+
         auto cs_count = GetInstance().ScriptEngine.WorkingScriptsCount();
         auto plugin_count = GetInstance().PluginSystem.GetNumPlugins();
-        std::ostringstream cleo_text;
-        cleo_text << "CLEO v" << CLEO_VERSION_STR;
-#ifdef _DEBUG
-        cleo_text << " DEBUG";
-#endif
-        SetTextAlign(1);
-        SetTextFont(2);
-        if (SetTextEdge) SetTextEdge(1);
-        SetLetterSize(CGameMenu_ScaleX(MenuManager, 0.23f), CGameMenu_ScaleY(MenuManager, 0.4f));
-
-        SetLetterColor(RGBA(/*0xE1, 0xE1, 0xE1, 0xFF*/0xAD, 0xCE, 0xC4, 0xFF));
-        TextDraw(CGameMenu_ScaleX(MenuManager, 6.0f), CGameMenu_ScaleY(MenuManager, 428.0f), cleo_text.str().c_str());
-        cleo_text.str("");
-
         if (cs_count || plugin_count)
         {
-            if (plugin_count) cleo_text << plugin_count << (plugin_count > 1 ? " plugins" : " plugin");
-            if (cs_count && plugin_count) cleo_text << " / ";
-            if (cs_count) cleo_text << cs_count << (cs_count > 1 ? " scripts" : " script");
-            //plugin_text << plugin_count << (plugin_count > 1 ? " plugins" : " plugin");
-            SetTextAlign(1);
-            //SetTextFont(2);
+            posY -= 15.0f * sizeY; // add space for bottom text
+        }
 
-            SetLetterSize(CGameMenu_ScaleX(MenuManager, 0.18f), CGameMenu_ScaleY(MenuManager, 0.34f));
+        // draw CLEO version text
+        std::ostringstream text;
+        text << "CLEO v" << CLEO_VERSION_STR;
+#ifdef _DEBUG
+        text << " ~r~~h~DEBUG";
+#endif
+        CFont::SetScale(sizeX, sizeY);
+        CFont::PrintString(posX, posY - 15.0f * sizeY, text.str().c_str());
 
-            SetLetterColor(RGBA(/*0xE1, 0xE1, 0xE1, 0xFF*/0xAD, 0xCE, 0xC4, 0xFF));
-            TextDraw(CGameMenu_ScaleX(MenuManager, 6.0f), CGameMenu_ScaleY(MenuManager, 436.0f), cleo_text.str().c_str());
+        // draw plugins / scripts text
+        if (cs_count || plugin_count)
+        {
+            text.str(""); // clear
+            if (plugin_count) text << plugin_count << (plugin_count > 1 ? " plugins" : " plugin");
+            if (cs_count && plugin_count) text << " / ";
+            if (cs_count) text << cs_count << (cs_count > 1 ? " scripts" : " script");
+
+            posY += 15.0f * sizeY; // line feed
+            sizeX *= subtextHeight;
+            sizeY *= subtextHeight;
+            CFont::SetScale(sizeX, sizeY);
+            CFont::PrintString(posX, posY - 15.0f * sizeY, text.str().c_str());
         }
 
         // execute callbacks
@@ -109,20 +92,8 @@ namespace CLEO
         TRACE("Injecting MenuStatusNotifier...");
         CGameVersionManager& gvm = GetInstance().VersionManager;
         MenuManager = gvm.TranslateMemoryAddress(MA_MENU_MANAGER);
-        TextDraw = gvm.TranslateMemoryAddress(MA_DRAW_TEXT_FUNCTION);
-        SetTextAlign = gvm.TranslateMemoryAddress(MA_SET_TEXT_ALIGN_FUNCTION);
-        SetTextFont = gvm.TranslateMemoryAddress(MA_SET_TEXT_FONT_FUNCTION);
-        SetTextEdge = gvm.TranslateMemoryAddress(MA_SET_TEXT_EDGE_FUNCTION);
-
-        // Meh...
-        CMenuManager__ScaleX = gvm.TranslateMemoryAddress(MA_CMENU_SCALE_X_FUNCTION);
-        CMenuManager__ScaleY = gvm.TranslateMemoryAddress(MA_CMENU_SCALE_Y_FUNCTION);
-
-        SetLetterSize = gvm.TranslateMemoryAddress(MA_SET_LETTER_SIZE_FUNCTION);
-        SetLetterColor = gvm.TranslateMemoryAddress(MA_SET_LETTER_COLOR_FUNCTION);
 
         inj.MemoryReadOffset(gvm.TranslateMemoryAddress(MA_CALL_CTEXTURE_DRAW_BG_RECT).address + 1, CTexture__DrawInRect, true);
-        //gvm.TranslateMemoryAddress(MA_CTEXTURE_DRAW_IN_RECT_FUNCTION);
         inj.ReplaceFunction(OnDrawMenuBackground, gvm.TranslateMemoryAddress(MA_CALL_CTEXTURE_DRAW_BG_RECT));
     }
 }

--- a/source/PluginSdkExternals.cpp
+++ b/source/PluginSdkExternals.cpp
@@ -1,11 +1,8 @@
 #include "stdafx.h"
 #include "CVector.h"
-#include "CRGBA.h"
 #include "CPed.h"
 
 bool CPed::IsPlayer() { return m_nPedType == PED_TYPE_PLAYER1 || m_nPedType == PED_TYPE_PLAYER2; }
 float CVector::Magnitude() { return sqrtf(x * x + y * y + z * z); }
 CVector::CVector() : x(0.0f), y(0.0f), z(0.0f) { }
 CVector::CVector(float _x, float _y, float _z) : x(_x), y(_y), z(_z) { }
-CRGBA::CRGBA(unsigned char _r, unsigned char _g, unsigned char _b, unsigned char _a) : r(_r), g(_g), b(_b), a(_a) { }
-CRGBA &CRGBA::operator=(const CRGBA &rgba) { r = rgba.r; g = rgba.g; b = rgba.b; a = rgba.a; return *this; }


### PR DESCRIPTION
Used CFont from plugin sdk instead of direct memory hacks.
Fixed aspect of main menu CLEO text.
Fixes https://github.com/cleolibrary/CLEO4/issues/48